### PR TITLE
Astar edits

### DIFF
--- a/draft/2022-12-substrate-newsletter.md
+++ b/draft/2022-12-substrate-newsletter.md
@@ -5,43 +5,13 @@ $title
 
 ## 🔦 Community highlights
 
-[**ASTAR NETWORK**](https://astar.network/) 
-
 Astar Network has introduced dApp [Staking Portal V2](https://medium.com/astar-network/our-dapp-staking-portal-v2-is-live-d4a1eba0563a), improving user experience to connect with parachain assets and encourage users to support developers through staking.  
-
-Astar invites Covalent to [Tech Talk #1](https://www.youtube.com/watch?v=MRYBg6ptkPw) to demonstrate analyzing on-chain data through Covalent API. 
-
-Astar invites RoosterDAO and RMRK to [Tech Talk #2](https://www.youtube.com/watch?v=MRYBg6ptkPw) discussion about using swanky-node to build an ink! contract that interacts with RMRK-pallet functionality to showcase evolving NFTs.  
-
-Astar [Tech Talk #3](https://www.youtube.com/watch?v=1JNNI4G9XS4)  about Building dApps using Astar.js to make building dApps on Astar easier. 
-
-Chris Li, CEO of Oak Network, discusses [Rust vs Solidity](https://twitter.com/Swankywasm/status/1596186173164380160) with the Swanky CLI team.
-
-[Astar Docs](https://docs.astar.network/) are now available in multiple languages (Portuguese, French, Indonesian with more to come in upcoming weeks) - powered by the Astar Community worldwide.
  
 * OpenZepplin will audit ink! and the Contract pallet. The ink! team and various Parachains are also working on a bounty proposal to kick off ink!ubator, a builder + auditor program to support companies building with ink! and to foster a Smart Contract auditing market. Part of the funding will also be used to develop open source audited smart contract templates and a React hooks library to make full stack development more ergonomic and fun. Join the conversation in the [ink! Element channel](https://matrix.to/#/!vvBpQdXROGzuQNhjEN:matrix.parity.io?via=matrix.parity.io) and read the [November ink! newsletter](https://use.ink/monthly-update/2022/11) for more updates.
 
 ## 📆 Upcoming events
  
 ## ☕️ Technical updates
-
-[**ASTAR NETWORK GITHUB**](https://github.com/AstarNetwork)
-
-Astar is the first Polkadot parachain to add light client support. Shiden will also support [Light Clients](https://github.com/polkadot-js/apps/pull/8262/files).
-Also publish guide for users, [HERE](https://medium.com/astar-network/decentralising-astar-with-light-clients-335bb9017546)
-
-Astar submits farming contracts to [wasm-showcase-dapps](https://github.com/AstarNetwork/wasm-showcase-dapps/tree/main/farming). There is a collection of templates to build dApps in WASM.
-
-Astar release [v4.32.0](https://github.com/AstarNetwork/Astar/releases/tag/v4.32.0) introduces XVM prototype v2 into Shibuya runtime. The latest XVM repository at [ink-xvm-sdk](https://github.com/AstarNetwork/ink-xvm-sdk).
-
-Hoonsubin (Astar CTO) submits [sub0-XVM-workshop](https://github.com/hoonsubin/sub0-xvm-workshop) repo. A demo of controlling EVM ERC20 tokens from a Substrate native account. Repo contains the full project to create a development environment where projects can reside either in EVM with Ethereum signers or WASM contract with Substrate native signers.
-
-Astar officially releases a Swanky v1. A tool for WASM smart contract developers, with support for integration tests. Swanky CLI can be downloaded via [NPM](https://www.npmjs.com/package/@astar-network/swanky-cli#usage).
-The latest documentation for Swanky can be found at the following: [Swanky CLI Github](https://github.com/AstarNetwork/swanky-cli) and [Swanky-Node Github](https://github.com/AstarNetwork/swanky-node)
-
-Pull-request merged for [dApp staking on Ledger](https://github.com/LedgerHQ/app-astar/pull/2), for dev mode.
-
-Entries for Polkadot's LATAM Hackathon Bounties being posted, [HERE](https://github.com/AstarNetwork/AstarBounties/pulls).
 
 ## 👀 Releases
 


### PR DESCRIPTION
Removed everything that's not directly relevant to the broader Substrate developer audience. In future we can just link to the Astar newsletter. Also being conscious of the currently small proportion of other ecosystem contributors. 